### PR TITLE
orderBook() selects the latest event for an order by timestamp instead of volume

### DIFF
--- a/R/order-book-reconstruction.R
+++ b/R/order-book-reconstruction.R
@@ -93,11 +93,11 @@ orderBook <- function(events, tp=as.POSIXlt(Sys.time(), tz="UTC"),
     active.orders <- events[events$id %in% active.order.ids, ]
     # remove order updates (deleted, changed) after now
     active.orders <- active.orders[active.orders$timestamp <= tp, ]
-    # for partial fills (order changed) <= now, keep the most recent change 
-    #(least remaining volume),
+    # for order changed(partial fills or order revisions) <= now, keep the most recent change 
+    # (latest timestamp),
     changed.orders <- active.orders$action == "changed"
     changed.before <- active.orders[changed.orders, ]
-    changed.before <- changed.before[order(changed.before[, "volume"]), ]
+    changed.before <- changed.before[order(changed.before[, "timestamp"], decreasing = TRUE), ]
     changed.before <- changed.before[!duplicated(changed.before$id), ]
     # remove, put back:
     # 1) remove all changed orders


### PR DESCRIPTION
Hi Phil!
I'd like to refactor obAnalytics to make it able to work with Bitstamp **and Bitfinex** data at the same time.  

If you don't mind I would propose several focused corrections which are necessary for Bitfinex and (hopefully) do not impact Bitstamp.  This  pull request shows an example. Since Bitfinex allows to change the order after it has been placed, the order's volume can be changed not only for  partial fills but at will of the order's owner. The price can be changed too and it happens rather often.

So in order to generate an order book snapshot correctly I propose to use 'timestamp' instead of 'volume' assuming that it will be fine for Bitstamp data too. 
