### PR TITLE
Fixes display of the cumulative sum of the bid volume by plotCurrentDepth()

### DIFF
--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -552,7 +552,8 @@ plotCurrentDepth <- function(order.book,
   p <- p + scale_colour_manual(values=col.pal)  
 
   # plot liquidity (cumulative sum of volume)
-  p <- p + geom_step()
+  p <- p + geom_step(data=subset(depth, side =="ask")) + 
+    geom_step(data=subset(depth, side =="bid"), direction="vh")
 
   # plot volume
   if(show.volume)


### PR DESCRIPTION
The following code is used to produce pictures below:

    lob <- orderBook(lob.data$events, tp=as.POSIXct("2015-05-01 01:12:17.429", tz="UTC"), bps.range=20)
    plotCurrentDepth(lob)


The output before the patch is applied:

![before](https://user-images.githubusercontent.com/949629/42417535-86476b92-8295-11e8-8b0b-348e12e782bb.png)

The output after:

![after](https://user-images.githubusercontent.com/949629/42417538-955155a8-8295-11e8-8b80-9b6af26af587.png)
