### PR TITLE
Some usability improvements of plotPriceLevels()

### DIFF
--- a/R/depth.R
+++ b/R/depth.R
@@ -147,7 +147,7 @@ filterDepth <- function(d, from, to) {
   if(nrow(pre) > 0) {
     pre$timestamp <- as.POSIXct(sapply(pre$timestamp, function(r) {
       max(from, r)
-    }), origin="1970-01-01", tz="UTC") 
+    }), origin="1970-01-01") 
   }
 
   # 2. add all volume change within the range.

--- a/R/visualisation.R
+++ b/R/visualisation.R
@@ -120,6 +120,7 @@ plotTrades <- function(trades, start.time=min(trades$timestamp),
 ##' @param volume.to Plot depth with volume <= this value relevant to
 ##'                  volume scale.
 ##' @param volume.scale Volume scale factor.
+##' @param price.by The increment for the 'limit price' scale (y)
 ##' @author phil
 ##' @examples
 ##' 
@@ -167,7 +168,8 @@ plotPriceLevels <- function(depth, spread=NULL, trades=NULL,
     price.to=NULL, 
     volume.from=NULL,
     volume.to=NULL,
-    volume.scale=1) {
+    volume.scale=1,
+    price.by=0.5) {
 
   depth$volume <- depth$volume*volume.scale
     
@@ -225,7 +227,7 @@ plotPriceLevels <- function(depth, spread=NULL, trades=NULL,
   depth.filtered[depth.filtered$volume==0, ]$volume <- NA
 
   # after filtering, plot.
-  plotPriceLevelsFaster(depth.filtered, spread, trades, show.mp, col.bias)
+  plotPriceLevelsFaster(depth.filtered, spread, trades, show.mp, col.bias, price.by)
 }
 
 ##' Poor man's heatmap.
@@ -245,10 +247,11 @@ plotPriceLevels <- function(depth, spread=NULL, trades=NULL,
 ##' @param show.mp If True, spread will be summarised as midprice.
 ##' @param col.bias 1 = uniform colour spectrum. 0.25 = bias toward 0.25
 ##'                 (more red less blue). <= 0 enables logarithmic scaling.
+##' @param price.by The increment for the 'limit price' scale (y)
 ##' @author phil
 ##' @keywords internal
 plotPriceLevelsFaster <- function(depth, spread, trades, show.mp=T, 
-    col.bias=0.1) {
+    col.bias=0.1, price.by) {
 
   # ggplot2 hack (see plotVolumePercentiles()) 
   price <- NULL; volume <- NULL; best.bid.price <- NULL; best.ask.price <- NULL
@@ -271,7 +274,7 @@ plotPriceLevelsFaster <- function(depth, spread, trades, show.mp=T,
       y=price, group=price, alpha=ifelse(is.na(volume), 0, 
       ifelse(volume < 1, 0.1, 1)))) #size=1
   p <- p + scale_y_continuous(breaks=seq(round(min(depth$price)), 
-      round(max(depth$price)), by=0.5), name="limit price")
+      round(max(depth$price)), by=price.by), name="limit price")
   if(log.10)
     p <- p + scale_colour_gradientn(colours=col.pal, trans="log10", 
       na.value="black")

--- a/man/plotPriceLevels.Rd
+++ b/man/plotPriceLevels.Rd
@@ -5,10 +5,11 @@
 \title{Plot order book price level heat map.}
 \usage{
 plotPriceLevels(depth, spread = NULL, trades = NULL, show.mp = T,
-  show.all.depth = F, col.bias = 0.1, start.time = head(depth$timestamp,
-  1), end.time = tail(depth$timestamp, 1), price.from = NULL,
+  show.all.depth = F, col.bias = 0.1,
+  start.time = head(depth$timestamp, 1),
+  end.time = tail(depth$timestamp, 1), price.from = NULL,
   price.to = NULL, volume.from = NULL, volume.to = NULL,
-  volume.scale = 1)
+  volume.scale = 1, price.by = 0.5)
 }
 \arguments{
 \item{depth}{The order book \code{\link{depth}}.}
@@ -39,6 +40,8 @@ volume.scale}
 volume scale.}
 
 \item{volume.scale}{Volume scale factor.}
+
+\item{price.by}{The increment for the 'limit price' scale (y)}
 }
 \description{
 Produces a visualisation of the limit order book depth through time.
@@ -92,4 +95,3 @@ with(lob.data, plotPriceLevels(depth, spread,
 \author{
 phil
 }
-

--- a/man/plotPriceLevelsFaster.Rd
+++ b/man/plotPriceLevelsFaster.Rd
@@ -4,7 +4,8 @@
 \alias{plotPriceLevelsFaster}
 \title{Poor man's heatmap.}
 \usage{
-plotPriceLevelsFaster(depth, spread, trades, show.mp = T, col.bias = 0.1)
+plotPriceLevelsFaster(depth, spread, trades, show.mp = T,
+  col.bias = 0.1, price.by)
 }
 \arguments{
 \item{depth}{The order book depth (lob.data$depth).}
@@ -17,6 +18,8 @@ plotPriceLevelsFaster(depth, spread, trades, show.mp = T, col.bias = 0.1)
 
 \item{col.bias}{1 = uniform colour spectrum. 0.25 = bias toward 0.25
 (more red less blue). <= 0 enables logarithmic scaling.}
+
+\item{price.by}{The increment for the 'limit price' scale (y)}
 }
 \description{
 Used by plotPriceLevels filtering function.
@@ -33,4 +36,3 @@ colour coded lines for each price level update.
 phil
 }
 \keyword{internal}
-


### PR DESCRIPTION
Scale y: a default 'limit price' increment of $0.5 is too small for current Bitcoin price levels - scale is often unreadable. 'price.by' parameter of plotPriceLevels() can be used to set an appropriate value for the increment.
Scale x: POSIXct objects are printed using the current timezone set
The proposed changes are rather useful when one looks for appropriate values of 'start.time', 'end.time', 'price.from' and 'price.to' parameters.