### PR TITLE
Closes  #25

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -12,8 +12,8 @@
 ##'   \item{timestamp}{Time in milliseconds when event received locally}
 ##'   \item{exchange.timestamp}{Time in milliseconds when order first created on
 ##' the exchange}
-##'   \item{price}{Price level of order event}
-##'   \item{volume}{Remaining order volume}
+##'   \item{price}{Price level of order event. It will be rounded by round(price, price.digits)}
+##'   \item{volume}{Remaining order volume. It will be rounded by round(price, volume.digits)}
 ##'   \item{action}{Event type (see below)}
 ##'   \item{direction}{Side of order book (bid or ask)}
 ##' }
@@ -32,6 +32,8 @@
 ##' included in the \code{inst/extdata} directory of this package.
 ##' 
 ##' @param csv.file Location of CSV file to import
+##' @param price.digits an integer indicating the number of decimal places in 'price' column of the CSV file
+##' @param volume.digits  an integer indicating the number of decimal places in 'volume' column of the CSV file
 ##' @return A list containing 4 data frames:
 ##' \describe{
 ##'   \item{\link{events}}{Limit order events.}
@@ -47,7 +49,7 @@
 ##' lob.data <- processData(csv.file)
 ##' }
 ##' @export processData
-processData <- function(csv.file) {
+processData <- function(csv.file, price.digits = 2, volume.digits = 8) {
 
   getZombieIds <- function(events, trades) {
     cancelled <- events[events$action == "deleted", ]$id

--- a/man/loadEventData.Rd
+++ b/man/loadEventData.Rd
@@ -4,10 +4,14 @@
 \alias{loadEventData}
 \title{Read raw limit order event data from a CSV file.}
 \usage{
-loadEventData(file)
+loadEventData(file, price.digits = 2, volume.digits = 8)
 }
 \arguments{
 \item{file}{Location of CSV file containing limit order events.}
+
+\item{price.digits}{an integer indicating the number of decimal places in 'price' column of the CSV file}
+
+\item{volume.digits}{an integer indicating the number of decimal places in 'volume' column of the CSV file}
 }
 \value{
 A data.frame containing the raw limit order events data.
@@ -27,4 +31,3 @@ limit order event.
 phil
 }
 \keyword{internal}
-

--- a/man/processData.Rd
+++ b/man/processData.Rd
@@ -4,10 +4,14 @@
 \alias{processData}
 \title{Import CSV file.}
 \usage{
-processData(csv.file)
+processData(csv.file, price.digits = 2, volume.digits = 8)
 }
 \arguments{
 \item{csv.file}{Location of CSV file to import}
+
+\item{price.digits}{an integer indicating the number of decimal places in 'price' column of the CSV file}
+
+\item{volume.digits}{an integer indicating the number of decimal places in 'volume' column of the CSV file}
 }
 \value{
 A list containing 4 data frames:
@@ -29,8 +33,8 @@ The CSV file is expected to contain 7 columns:
   \item{timestamp}{Time in milliseconds when event received locally}
   \item{exchange.timestamp}{Time in milliseconds when order first created on
 the exchange}
-  \item{price}{Price level of order event}
-  \item{volume}{Remaining order volume}
+  \item{price}{Price level of order event. It will be rounded by round(price, price.digits)}
+  \item{volume}{Remaining order volume. It will be rounded by round(price, volume.digits)}
   \item{action}{Event type (see below)}
   \item{direction}{Side of order book (bid or ask)}
 }
@@ -58,4 +62,3 @@ lob.data <- processData(csv.file)
 \author{
 phil
 }
-


### PR DESCRIPTION
Below is the the input file for processData() which contains non-integral 'volume'
[events.csv.gz](https://github.com/phil8192/ob-analytics/files/2599707/events.csv.gz) and which can be used for testing. 

The current version of obAnalytics classifies events in the file as follows:

| unknown | flashed-limit|resting-limit|market-limit|pacman|market|
| ---- | ------| -------|---|---|---|
| 994 | 16062 |1350|38| 33|311|

After this patch:

| unknown | flashed-limit|resting-limit|market-limit|pacman|market|
| ---- | ------| -------|---|---|---|
| 9 | 16062 |1674|254| 33|756|

Please note that I have re-implemented processData() in Postgresql database using different algorithm(s) (I fully reconstruct order book in time, match events using information from live_trades API etc ) and the correct classification of the given events is:

| unknown | flashed-limit|resting-limit|market-limit|pacman|market|
| ---- | ------| -------|---|---|---|
| 1 | 16062 |1669|443| 33|580|

The Postgresql's version of 'events' (as well as depth, depth.summary and trades) are in the file below
[correct.rda.gz](https://github.com/phil8192/ob-analytics/files/2599772/correct.rda.gz). 

Here is the example of the visual differences between datasets:

The patched processData() version:
![incorrect](https://user-images.githubusercontent.com/949629/48775603-9c102a00-ecde-11e8-8b33-55dab713c285.png)

Postgresql version :

![correct](https://user-images.githubusercontent.com/949629/48775621-a6cabf00-ecde-11e8-8f8f-d5a0f835cdc0.png)











