### PR TITLE
Correct price labels for cheap (less than $1) curriencies

### DIFF
--- a/man/plotPriceLevels.Rd
+++ b/man/plotPriceLevels.Rd
@@ -9,7 +9,7 @@ plotPriceLevels(depth, spread = NULL, trades = NULL, show.mp = T,
   start.time = head(depth$timestamp, 1),
   end.time = tail(depth$timestamp, 1), price.from = NULL,
   price.to = NULL, volume.from = NULL, volume.to = NULL,
-  volume.scale = 1, price.by = 0.5)
+  volume.scale = 1, price.by = NULL)
 }
 \arguments{
 \item{depth}{The order book \code{\link{depth}}.}


### PR DESCRIPTION
If the price of the currency to be visualized is below $1, its price is not shown (rounded to zero) as below:

![before](https://user-images.githubusercontent.com/949629/53680787-26f6bc80-3cf1-11e9-89f4-4f565c5c9f02.png)

The patch fixes that:

![after](https://user-images.githubusercontent.com/949629/53680804-59081e80-3cf1-11e9-95d3-ec98616158f5.png)

